### PR TITLE
fix: 서비스 소개 페이지 모바일 화면 축소 시 레이아웃 쏠림 현상 수정

### DIFF
--- a/src/pages/service-introduction/components/EvaluationStep.jsx
+++ b/src/pages/service-introduction/components/EvaluationStep.jsx
@@ -39,7 +39,7 @@ function EvaluationStep({ step, color, title, desc, marginBottom }) {
                 </span>
             </div>
 
-            <div className="flex flex-col flex-1 min-w-0 relative max-[768px]:mt-[10px] max-[768px]:ml-[20px]" ref={containerRef}>
+            <div className="flex flex-col flex-1 min-w-0 relative overflow-hidden max-[768px]:mt-[10px] max-[768px]:ml-[20px]" ref={containerRef}>
                 <h3 className="text-[#000000] text-[20px] max-[768px]:text-[16px] font-[500] mb-[12px] leading-none">
                     {title}
                 </h3>

--- a/src/pages/service-introduction/components/ServiceCaseCard.jsx
+++ b/src/pages/service-introduction/components/ServiceCaseCard.jsx
@@ -32,7 +32,7 @@ function ServiceCaseCard({ img, title, desc }) {
     return (
         <div className="flex items-center gap-[65px]">
             <img src={img} alt={title} className="w-[103px] h-[103px] shrink-0" />
-            <div className="flex flex-col gap-[12px] flex-1 min-w-0 relative" ref={containerRef}>
+            <div className="flex flex-col gap-[12px] flex-1 min-w-0 relative overflow-hidden" ref={containerRef}>
                 <h3 className="text-[20px] max-[768px]:text-[16px] font-[500] leading-[120%]">{title}</h3>
                 
                 {/* Visible responsive text */}


### PR DESCRIPTION
## 연관된 이슈

#414 

<br>

## 작업 내용

- ServiceCaseCard, EvaluationStep: 줄바꿈 측정용 숨김 요소(절대 위치)가 뷰포트 너비를 초과하여 브라우저 전체 너비가 넓어지는(가로 스크롤 이슈 및 축소 시 쏠림) 문제 해결 (부모 래퍼에 overflow-hidden 추가)

<br> 

## 리뷰 요구사항(선택)
