### PR TITLE
hotfix: pass_score null 일 경우 오류 발생 문제 해결

### DIFF
--- a/src/hooks/useCreateAnalysis.ts
+++ b/src/hooks/useCreateAnalysis.ts
@@ -23,13 +23,15 @@ export const useCreateAnalysis = () => {
         }
 
         if (event.type === "pass_score") {
-          const { x, y, z, overall } = event.data as any;
-          setPassScoreData({
-            x: Math.ceil(x * 10) / 10,
-            y: Math.ceil(y * 10) / 10,
-            z: Math.ceil(z * 10) / 10,
-            overall,
-          });
+          if (event.data) {
+            const { x, y, z, overall } = event.data as any;
+            setPassScoreData({
+              x: Math.ceil(x * 10) / 10,
+              y: Math.ceil(y * 10) / 10,
+              z: Math.ceil(z * 10) / 10,
+              overall,
+            });
+          }
           return;
         }
 

--- a/src/pages/analysis-page/components/AnalysisDiagnosis.tsx
+++ b/src/pages/analysis-page/components/AnalysisDiagnosis.tsx
@@ -59,7 +59,7 @@ export default function AnalysisDiagnosis({
       <section>
         <AnalysisHeader title="3D 평가 세부 결과" />
         {sections.map((section) => (
-          <div className="mb-[10px]">
+          <div key={section.axis} className="mb-[10px]">
             <h3 className="font-semibold text-lg">{section.title}</h3>
             <div className="flex mt-4 w-full gap-10">
               <div className="w-[350px]">
@@ -151,9 +151,9 @@ export default function AnalysisDiagnosis({
             <h3 className="font-semibold text-lg mb-1">요약</h3>
             <div className="text-lg flex flex-col gap-[7px]">
               {evaluationResult?.scoreSummary?.map((summary, index) => (
-                <div className="flex gap-2">
+                <div key={index} className="flex gap-2">
                   <span>• </span>
-                  <p key={index}>{summary}</p>
+                  <p>{summary}</p>
                 </div>
               ))}
             </div>

--- a/src/pages/input-page/loading/layouts/AnalysisStateSection.jsx
+++ b/src/pages/input-page/loading/layouts/AnalysisStateSection.jsx
@@ -42,8 +42,10 @@ function AnalysisStateSection({ completed, error, title, completedTitle, items, 
   useEffect(() => {
     if (sectionRef.current) {
       requestAnimationFrame(() => {
-        sectionRef.current.style.opacity = "1";
-        sectionRef.current.style.transform = "translateY(0)";
+        if (sectionRef.current) {
+          sectionRef.current.style.opacity = "1";
+          sectionRef.current.style.transform = "translateY(0)";
+        }
       });
     }
   }, []);


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- (#을 입력하고 해당하는 이슈번호에서 엔터!)

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- useCreateAnalysis에서 pass_score의 data가  null일 경우, 기존에는 유효성 처리를 하지 않아서 에러 발생. 지금은 무시하고 진행하도록 수정

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 
