### PR TITLE
fix: 랜딩페이지 양쪽 여백 헤더와 동일하게 수정

### DIFF
--- a/src/pages/landing-page/5-review/Review.tsx
+++ b/src/pages/landing-page/5-review/Review.tsx
@@ -14,7 +14,7 @@ export default function Review() {
   });
 
   return (
-    <ExplainSectionLayout className="max-w-[1200px]">
+    <ExplainSectionLayout>
       <SubTitle
         title="자기소개서 평가 및 수정"
         discription="개선전략을 반영한 자기소개서 첨삭 및 수정 후 합격가능성을 재평가합니다."

--- a/src/pages/landing-page/layouts/ExplainSectionLayout.tsx
+++ b/src/pages/landing-page/layouts/ExplainSectionLayout.tsx
@@ -12,8 +12,8 @@ export default function ExplainSectionLayout({
     <section
       className={cn(
         "flex flex-col items-center px-[20px] pt-[80px] pb-[50px] bg-[#F4F6F8] h-fit",
-        "lg:pt-[120px] lg:h-screen",
-        "md:px-[40px] md:pt-[130px]",
+        "lg:px-[calc((100vw-1200px)/2)] lg:pt-[120px] lg:h-screen",
+        "min-[894px]:px-[40px] md:pt-[130px]",
         className,
       )}
     >


### PR DESCRIPTION
## 연관된 이슈

- #472 

<br>

## 작업 내용

> 랜딩페이지 양쪽 여백 헤더와 동일하게 수정
 
<img width="1914" height="924" alt="image" src="https://github.com/user-attachments/assets/79012e33-7472-4bb3-a5dd-af06271af99b" />



